### PR TITLE
change default value for attendees to empty list

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/calendar/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/calendar/base.py
@@ -162,9 +162,10 @@ class GoogleCalendarToolSpec(BaseToolSpec):
         credentials = self._get_credentials()
         service = build("calendar", "v3", credentials=credentials)
 
-        attendees_list = []
-        for attendee in attendees:
-            attendees_list.append({"email": attendee})
+        attendees_list = (
+            [{"email": attendee} for attendee in attendees] if attendees else []
+        )
+
         start_time = (
             datetime.datetime.strptime(start_datetime, "%Y-%m-%dT%H:%M:%S%z")
             .astimezone()


### PR DESCRIPTION
# Description

```
Calling function: create_event with args: {"title":"*******","start_datetime":"*********","end_datetime":"********","location":"*********"}
Got output: Error: 'NoneType' object is not iterable
```
The create_event function throws the above error when there are no attendees in the user query. 
Fixes # (issue)

Change the default value for attendees from None to an empty list

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
